### PR TITLE
Fix invalid command message

### DIFF
--- a/src/registry.js
+++ b/src/registry.js
@@ -107,7 +107,7 @@ class CommandRegistry {
 
 			// Verify that it's an actual command
 			if(!command || !(command instanceof Command)) {
-				this.client.emit('warn', `Attempting to register an invalid command object: ${command.name}; skipping.`);
+				this.client.emit('warn', `Attempting to register an invalid command object: ${command}; skipping.`);
 				continue;
 			}
 

--- a/src/registry.js
+++ b/src/registry.js
@@ -107,7 +107,7 @@ class CommandRegistry {
 
 			// Verify that it's an actual command
 			if(!command || !(command instanceof Command)) {
-				this.client.emit('warn', 'Attempting to register an invalid command object: ${command}; skipping.');
+				this.client.emit('warn', `Attempting to register an invalid command object: ${command.name}; skipping.`);
 				continue;
 			}
 


### PR DESCRIPTION
Invalid command message was using a regular string instead of a template literal. I also changed `command` to `command.name`, to better show which command was invalid.