### PR TITLE
Fix spelling mistake in the help command (@user, Sent ->a<- you a DM with information)

### DIFF
--- a/src/commands/util/help.js
+++ b/src/commands/util/help.js
@@ -53,7 +53,7 @@ module.exports = class HelpCommand extends Command {
 				const messages = [];
 				try {
 					messages.push(await msg.direct(help));
-					if(msg.channel.type !== 'dm') messages.push(await msg.reply('Sent a you a DM with information.'));
+					if(msg.channel.type !== 'dm') messages.push(await msg.reply('Sent you a DM with information.'));
 				} catch(err) {
 					messages.push(await msg.reply('Unable to send you the help DM. You probably have DMs disabled.'));
 				}
@@ -92,7 +92,7 @@ module.exports = class HelpCommand extends Command {
 						`).join('\n\n')
 					}
 				`, { split: true }));
-				if(msg.channel.type !== 'dm') messages.push(await msg.reply('Sent a you a DM with information.'));
+				if(msg.channel.type !== 'dm') messages.push(await msg.reply('Sent you a DM with information.'));
 			} catch(err) {
 				messages.push(await msg.reply('Unable to send you the help DM. You probably have DMs disabled.'));
 			}


### PR DESCRIPTION
Bug noticed by @Cruzercru in the discord.js guild: https://cdn.discordapp.com/attachments/237830519532945409/268338302904565760/unknown.png