### PR TITLE
Make the ArgumentCollector correctly return the answers array.

### DIFF
--- a/src/commands/collector.js
+++ b/src/commands/collector.js
@@ -80,7 +80,7 @@ class ArgumentCollector {
 						values: null,
 						cancelled: result.cancelled,
 						prompts: [].concat(...results.map(res => res.prompts)),
-						responses: [].concat(...results.map(res => res.responses))
+						answers: [].concat(...results.map(res => res.answers))
 					};
 				}
 
@@ -97,7 +97,7 @@ class ArgumentCollector {
 			values,
 			cancelled: null,
 			prompts: [].concat(...results.map(res => res.prompts)),
-			responses: [].concat(...results.map(res => res.responses))
+			answers: [].concat(...results.map(res => res.answers))
 		};
 	}
 }


### PR DESCRIPTION
Currently answers is for returning undefined and responses is returning an array of a single undefined.
Since the docs states them as answers and other classes are using answers too, I changed it that way.

"WHOOPSIES"