### PR TITLE
Allow direct, say, reply, and code to use MessageOptions without content

### DIFF
--- a/src/commands/message.js
+++ b/src/commands/message.js
@@ -346,6 +346,10 @@ class CommandMessage {
 	 * @return {Promise<Message|Message[]>}
 	 */
 	direct(content, options) {
+		if (!options && typeof content === 'object' && !(content instanceof Array)) {
+			options = content;
+			content = '';
+		}
 		return this.respond({ type: 'direct', content, options });
 	}
 

--- a/src/commands/message.js
+++ b/src/commands/message.js
@@ -326,6 +326,10 @@ class CommandMessage {
 	 * @return {Promise<Message|Message[]>}
 	 */
 	say(content, options) {
+		if(!options && typeof content === 'object' && !(content instanceof Array)) {
+			options = content;
+			content = '';
+		}
 		return this.respond({ type: 'plain', content, options });
 	}
 
@@ -336,6 +340,10 @@ class CommandMessage {
 	 * @return {Promise<Message|Message[]>}
 	 */
 	reply(content, options) {
+		if(!options && typeof content === 'object' && !(content instanceof Array)) {
+			options = content;
+			content = '';
+		}
 		return this.respond({ type: 'reply', content, options });
 	}
 
@@ -361,6 +369,10 @@ class CommandMessage {
 	 * @return {Promise<Message|Message[]>}
 	 */
 	code(lang, content, options) {
+		if(!options && typeof content === 'object' && !(content instanceof Array)) {
+			options = content;
+			content = '';
+		}
 		if(typeof options !== 'object') options = {};
 		options.code = lang;
 		return this.respond({ type: 'code', content, options });

--- a/src/commands/message.js
+++ b/src/commands/message.js
@@ -346,7 +346,7 @@ class CommandMessage {
 	 * @return {Promise<Message|Message[]>}
 	 */
 	direct(content, options) {
-		if (!options && typeof content === 'object' && !(content instanceof Array)) {
+		if(!options && typeof content === 'object' && !(content instanceof Array)) {
 			options = content;
 			content = '';
 		}


### PR DESCRIPTION
This is similar (in fact it works exactly like) to the way discord.js handles `send`. This allows the user to use `msg.direct({embed})` instead of having to do `msg.direct('', {embed})` when sending embeds or files to the user.

Fully tested and confirmed working.