### PR TITLE
Custom hasPermission Reply Message

### DIFF
--- a/src/commands/base.js
+++ b/src/commands/base.js
@@ -282,7 +282,9 @@ class Command {
 	isUsable(message = null) {
 		if(!message) return this._defaultEnabled;
 		if(this.guildOnly && message && !message.guild) return false;
-		return this.isEnabledIn(message.guild) && this.hasPermission(message);
+		let hasPermission = this.hasPermission(message);
+		if(typeof hasPermission === 'string') hasPermission = false;
+		return this.isEnabledIn(message.guild) && hasPermission;
 	}
 
 	/**

--- a/src/commands/base.js
+++ b/src/commands/base.js
@@ -197,7 +197,7 @@ class Command {
 	/**
 	 * Checks a user's permission in a guild
 	 * @param {CommandMessage} message - The triggering command message
-	 * @return {boolean}
+	 * @return {boolean|string} Either boolean, or a custom string response
 	 */
 	hasPermission(message) { // eslint-disable-line no-unused-vars
 		return true;

--- a/src/commands/base.js
+++ b/src/commands/base.js
@@ -282,9 +282,8 @@ class Command {
 	isUsable(message = null) {
 		if(!message) return this._defaultEnabled;
 		if(this.guildOnly && message && !message.guild) return false;
-		let hasPermission = this.hasPermission(message);
-		if(typeof hasPermission === 'string') hasPermission = false;
-		return this.isEnabledIn(message.guild) && hasPermission;
+		const hasPermission = this.hasPermission(message);
+		return this.isEnabledIn(message.guild) && hasPermission && typeof hasPermission !== 'string';
 	}
 
 	/**

--- a/src/commands/base.js
+++ b/src/commands/base.js
@@ -197,7 +197,7 @@ class Command {
 	/**
 	 * Checks a user's permission in a guild
 	 * @param {CommandMessage} message - The triggering command message
-	 * @return {boolean|string} Either boolean, or a custom string response
+	 * @return {boolean|string} Whether the user has permission, or an error message to respond with if they don't
 	 */
 	hasPermission(message) { // eslint-disable-line no-unused-vars
 		return true;

--- a/src/commands/message.js
+++ b/src/commands/message.js
@@ -136,9 +136,8 @@ class CommandMessage {
 		const hasPermission = this.command.hasPermission(this);
 		if(!hasPermission || typeof hasPermission === 'string') {
 			this.client.emit('commandBlocked', this, 'permission');
-			return this.reply(
-				typeof hasPermission === 'string' ? hasPermission : `You do not have permission to use the \`${this.command.name}\` command.`
-			);
+			if(typeof hasPermission === 'string') return this.reply(hasPermission);
+			else return this.reply(`You do not have permission to use the \`${this.command.name}\` command.`);
 		}
 
 		// Throttle the command

--- a/src/commands/message.js
+++ b/src/commands/message.js
@@ -133,11 +133,12 @@ class CommandMessage {
 		}
 
 		// Check if the command doesn't have permission to be run
-		let hasPermission = this.command.hasPermission(this) || false;
+		const hasPermission = this.command.hasPermission(this);
 		if(!hasPermission || typeof hasPermission === 'string') {
 			this.client.emit('commandBlocked', this, 'permission');
-			if(!hasPermission) hasPermission = `You do not have permission to use the \`${this.command.name}\` command.`;
-			return this.reply(hasPermission);
+			return this.reply(
+				typeof hasPermission === 'string' ? hasPermission : `You do not have permission to use the \`${this.command.name}\` command.`
+			);
 		}
 
 		// Throttle the command

--- a/src/commands/message.js
+++ b/src/commands/message.js
@@ -119,7 +119,7 @@ class CommandMessage {
 			this.message.member = await this.message.guild.fetchMember(this.message.author);
 		}
 
-		// Make sure the command is usable
+		// Make sure the command is usable in this context
 		if(this.command.guildOnly && !this.message.guild) {
 			/**
 			 * Emitted when a command is prevented from running
@@ -132,7 +132,7 @@ class CommandMessage {
 			return this.reply(`The \`${this.command.name}\` command must be used in a server channel.`);
 		}
 
-		// Check if the command doesn't have permission to be run
+		// Ensure the user has permission to use the command
 		const hasPermission = this.command.hasPermission(this);
 		if(!hasPermission || typeof hasPermission === 'string') {
 			this.client.emit('commandBlocked', this, 'permission');

--- a/src/commands/message.js
+++ b/src/commands/message.js
@@ -131,9 +131,13 @@ class CommandMessage {
 			this.client.emit('commandBlocked', this, 'guildOnly');
 			return this.reply(`The \`${this.command.name}\` command must be used in a server channel.`);
 		}
-		if(!this.command.hasPermission(this)) {
+
+		// Check if the command doesn't have permission to be run
+		let hasPermission = this.command.hasPermission(this) || false;
+		if(!hasPermission || typeof hasPermission === 'string') {
 			this.client.emit('commandBlocked', this, 'permission');
-			return this.reply(`You do not have permission to use the \`${this.command.name}\` command.`);
+			if(!hasPermission) hasPermission = `You do not have permission to use the \`${this.command.name}\` command.`;
+			return this.reply(hasPermission);
 		}
 
 		// Throttle the command


### PR DESCRIPTION
This is probably not the best way to implement this feature but it's been tested and does work so I thought I'd see if it's okay. Basically this allows the hasPermission method to, instead of returning true/false (which do still work and will show the default no permission response) will also allow the user to return a string. The string will be used to send a custom reply when the hasPermission method does not pass. This allows you to more accurately tell your users what they're missing to use the command.

The way I'm doing it is probably disgusting, but it works. Also I had to do a weird method for the `hasPermission` variable because for some reason when I did `return false` it was complaining about reading from null.