### PR TITLE
Fix for selfbot permissions in enable, disable, and groups

### DIFF
--- a/src/commands/commands/disable.js
+++ b/src/commands/commands/disable.js
@@ -41,6 +41,7 @@ module.exports = class DisableCommandCommand extends Command {
 	}
 
 	hasPermission(msg) {
+		if(this.client.options.selfbot) return true;
 		if(!msg.guild) return this.client.isOwner(msg.author);
 		return msg.member.hasPermission('ADMINISTRATOR');
 	}

--- a/src/commands/commands/enable.js
+++ b/src/commands/commands/enable.js
@@ -41,6 +41,7 @@ module.exports = class EnableCommandCommand extends Command {
 	}
 
 	hasPermission(msg) {
+		if(this.client.options.selfbot) return true;
 		if(!msg.guild) return this.client.isOwner(msg.author);
 		return msg.member.hasPermission('ADMINISTRATOR');
 	}

--- a/src/commands/commands/groups.js
+++ b/src/commands/commands/groups.js
@@ -15,6 +15,7 @@ module.exports = class ListGroupsCommand extends Command {
 	}
 
 	hasPermission(msg) {
+		if(this.client.options.selfbot) return true;
 		if(!msg.guild) return this.client.isOwner(msg.author);
 		return msg.member.hasPermission('ADMINISTRATOR');
 	}


### PR DESCRIPTION
This allows enable, disable, and groups to work in any guild if the client is running in selfbot mode.