### PR TITLE
Fix Uncaught Command Promise Error

### DIFF
--- a/src/commands/message.js
+++ b/src/commands/message.js
@@ -178,7 +178,7 @@ class CommandMessage {
 			const promise = this.command.run(this, args, fromPattern).catch(err => {
 				throw err;
 			});
-			
+
 			/**
 			 * Emitted when running a command
 			 * @event CommandoClient#commandRun

--- a/src/commands/message.js
+++ b/src/commands/message.js
@@ -175,7 +175,10 @@ class CommandMessage {
 		const typingCount = this.message.channel.typingCount;
 		try {
 			this.client.emit('debug', `Running command ${this.command.groupID}:${this.command.memberName}.`);
-			const promise = this.command.run(this, args, fromPattern);
+			const promise = this.command.run(this, args, fromPattern).catch(err => {
+				throw err;
+			});
+			
 			/**
 			 * Emitted when running a command
 			 * @event CommandoClient#commandRun


### PR DESCRIPTION
This fixes an issue where the command promise gets rejected before V8 reaches the await - resulting in an Uncaught Promise Error.

Illustrating the issue with an absurd example:
```js
async run(msg) {
    throw new Error('Promise rejected before reaching await.');
}
```