### PR TITLE
Fix for resolveString not being a function

### DIFF
--- a/src/commands/message.js
+++ b/src/commands/message.js
@@ -245,7 +245,7 @@ class CommandMessage {
 			}
 		}
 
-		content = discord.Util.resolveString(content);
+		content = this.client.resolver.resolveString(content);
 
 		switch(type) {
 			case 'plain':


### PR DESCRIPTION
Simple fix for resolveString not being a function. Changed to `this.client.resolver.resolveString()`