### PR TITLE
Argument.validate missing parameter

### DIFF
--- a/src/commands/argument.js
+++ b/src/commands/argument.js
@@ -213,7 +213,7 @@ class Argument {
 		while(true) { // eslint-disable-line no-constant-condition
 			/* eslint-disable no-await-in-loop */
 			let value = values && values[currentVal] ? values[currentVal] : null;
-			let valid = value ? await this.validate(value) : false;
+			let valid = value ? await this.validate(value, msg) : false;
 			let attempts = 0;
 
 			while(!valid || typeof valid === 'string') {


### PR DESCRIPTION
The missing parameter for `validate` in `obtainInfinite` prevented users and members (and maybe more?) from being infinitely provided.  Simple fix.

Btw, is it possible this change could get backported to the 11.1 branch?