### PR TITLE
Use declaration merging to "forward declare" sqlite

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,3 +1,8 @@
+declare module 'sqlite' {
+	export interface Database {}
+	export interface Statement {}
+}
+
 declare module 'discord.js-commando' {
 	import { Channel, Client, ClientOptions, ClientUserSettings, Collection, DMChannel, Emoji, GroupDMChannel, Guild, GuildChannel, GuildMember, GuildResolvable, Message, MessageAttachment, MessageEmbed, MessageOptions, MessageReaction, ReactionEmoji, RichEmbed, Role, Snowflake, StringResolvable, TextChannel, User, UserResolvable, Webhook } from 'discord.js';
 	import { Database as SQLiteDatabase, Statement as SQLiteStatement } from 'sqlite';


### PR DESCRIPTION
This allows typescript to compile the entire module without having `node-sqlite` installed.

I've done some testing to make sure this doesn't interfere with the real sqlite module if it is installed.  As far as I can tell, this does not interfere at all.  I've also tested using VSCode, but even then it will still find the 'right' definition of `Database` and `Statement`, though it will acknowledge that both types were defined twice.  There isn't any documentation (that I could find) for declaration merging in this case, so I don't know if this is intended behavior or not.  Regardless, another pair of eyes should test to make sure nothing breaks 👀 

Also, if this could be backported to the 11.1 branch, I'd appreciate it
