### PR TITLE
Fetch the GuildMember for the ClientUser if it doesn't already exist

### DIFF
--- a/src/commands/message.js
+++ b/src/commands/message.js
@@ -119,6 +119,11 @@ class CommandMessage {
 			this.message.member = await this.message.guild.members.fetch(this.message.author);
 		}
 
+		// Obtain the member for the ClientUser if it doesn't already exist
+		if(this.message.channel.type === 'text' && !this.message.guild.members.has(this.client.user.id)) {
+			await this.message.guild.members.fetch(this.client.user.id);
+		}
+
 		// Make sure the command is usable in this context
 		if(this.command.guildOnly && !this.message.guild) {
 			/**


### PR DESCRIPTION
On occasion, the `GuildMember` for the `ClientUser` will be uncached, causing an error if any permissions checks are done on the `ClientUser`. This PR prevents that member from being uncached, and should be done, especially if we plan to implement things like `clientPermissions` in the future where we'll be needing that member.