### PR TITLE
Make CommandFormatError more descriptive

### DIFF
--- a/src/errors/command-format.js
+++ b/src/errors/command-format.js
@@ -10,11 +10,11 @@ class CommandFormatError extends FriendlyError {
 	 */
 	constructor(msg) {
 		super(
-			`Invalid command format. Use ${msg.anyUsage(
-				`help ${msg.command.name}`,
+			`Invalid command format. Please use the proper format, ${msg.usage(
+				msg.command.format,
 				msg.guild ? undefined : null,
 				msg.guild ? undefined : null
-			)} for information.`
+			)}.`
 		);
 		this.name = 'CommandFormatError';
 	}

--- a/src/errors/command-format.js
+++ b/src/errors/command-format.js
@@ -10,11 +10,15 @@ class CommandFormatError extends FriendlyError {
 	 */
 	constructor(msg) {
 		super(
-			`Invalid command format. Please use the proper format, ${msg.usage(
+			`Invalid command usage. The \`${msg.command.name}\` command's accepted format is: ${msg.usage(
 				msg.command.format,
 				msg.guild ? undefined : null,
 				msg.guild ? undefined : null
-			)}.`
+			)}. Use ${msg.usage(
+				`help ${msg.command.name}`,
+				msg.guild ? undefined : null,
+				msg.guild ? undefined : null
+			)} for more information.`
 		);
 		this.name = 'CommandFormatError';
 	}


### PR DESCRIPTION
This just makes the response in `CommandFormatError` more descriptive, users should be shown the proper format of the command when they enter it incorrectly.