### PR TITLE
ownerOnly option.

### DIFF
--- a/src/commands/base.js
+++ b/src/commands/base.js
@@ -24,7 +24,7 @@ class Command {
 	 * @property {string} [details] - A detailed description of the command and its functionality
 	 * @property {string[]} [examples] - Usage examples of the command
 	 * @property {boolean} [guildOnly=false] - Whether or not the command should only function in a guild channel
-	 * @property {boolean} [ownerOnly=false] - Whether or not the command is usable only be an owner
+	 * @property {boolean} [ownerOnly=false] - Whether or not the command is usable only by an owner
 	 * @property {PermissionResolvable[]} [clientPermissions] - Permissions required by the client to use the command.
 	 * @property {PermissionResolvable[]} [userPermissions] - Permissions required by the user to use the command.
 	 * @property {ThrottlingOptions} [throttling] - Options for throttling usages of the command.

--- a/src/commands/base.js
+++ b/src/commands/base.js
@@ -24,6 +24,7 @@ class Command {
 	 * @property {string} [details] - A detailed description of the command and its functionality
 	 * @property {string[]} [examples] - Usage examples of the command
 	 * @property {boolean} [guildOnly=false] - Whether or not the command should only function in a guild channel
+	 * @property {boolean} [ownerOnly=false] - Whether or not the command is usable only be an owner
 	 * @property {PermissionResolvable[]} [clientPermissions] - Permissions required by the client to use the command.
 	 * @property {PermissionResolvable[]} [userPermissions] - Permissions required by the user to use the command.
 	 * @property {ThrottlingOptions} [throttling] - Options for throttling usages of the command.
@@ -127,6 +128,12 @@ class Command {
 		this.guildOnly = !!info.guildOnly;
 
 		/**
+		 * Whether the command can only be used by an owner
+		 * @type {boolean}
+		 */
+		this.ownerOnly = !!info.ownerOnly;
+
+		/**
 		 * Permissions required by the client to use the command.
 		 * @type {?PermissionResolvable[]}
 		 */
@@ -213,7 +220,11 @@ class Command {
 	 * @param {CommandMessage} message - The triggering command message
 	 * @return {boolean|string} Whether the user has permission, or an error message to respond with if they don't
 	 */
-	hasPermission(message) { // eslint-disable-line no-unused-vars
+	hasPermission(message) {
+		if(this.ownerOnly && !this.client.isOwner(message.author)) {
+			return `The \`${this.name}\` command can only be used by the bot owner.`;
+		}
+
 		if(message.channel.type === 'text' && this.userPermissions) {
 			const missing = message.channel.permissionsFor(message.author).missing(this.userPermissions);
 			if(missing.length > 0) {

--- a/src/commands/base.js
+++ b/src/commands/base.js
@@ -131,7 +131,7 @@ class Command {
 		 * Whether the command can only be used by an owner
 		 * @type {boolean}
 		 */
-		this.ownerOnly = !!info.ownerOnly;
+		this.ownerOnly = Boolean(info.ownerOnly);
 
 		/**
 		 * Permissions required by the client to use the command.

--- a/src/commands/commands/load.js
+++ b/src/commands/commands/load.js
@@ -15,6 +15,7 @@ module.exports = class LoadCommandCommand extends Command {
 				Only the bot owner(s) may use this command.
 			`,
 			examples: ['load some-command'],
+			ownerOnly: true,
 			guarded: true,
 
 			args: [
@@ -41,10 +42,6 @@ module.exports = class LoadCommandCommand extends Command {
 				}
 			]
 		});
-	}
-
-	hasPermission(msg) {
-		return this.client.isOwner(msg.author);
 	}
 
 	async run(msg, args) {

--- a/src/commands/commands/reload.js
+++ b/src/commands/commands/reload.js
@@ -16,6 +16,7 @@ module.exports = class ReloadCommandCommand extends Command {
 				Only the bot owner(s) may use this command.
 			`,
 			examples: ['reload some-command'],
+			ownerOnly: true,
 			guarded: true,
 
 			args: [
@@ -39,10 +40,6 @@ module.exports = class ReloadCommandCommand extends Command {
 				}
 			]
 		});
-	}
-
-	hasPermission(msg) {
-		return this.client.isOwner(msg.author);
 	}
 
 	async run(msg, args) {

--- a/src/commands/commands/unload.js
+++ b/src/commands/commands/unload.js
@@ -15,6 +15,7 @@ module.exports = class UnloadCommandCommand extends Command {
 				Only the bot owner(s) may use this command.
 			`,
 			examples: ['unload some-command'],
+			ownerOnly: true,
 			guarded: true,
 
 			args: [
@@ -32,10 +33,6 @@ module.exports = class UnloadCommandCommand extends Command {
 				}
 			]
 		});
-	}
-
-	hasPermission(msg) {
-		return this.client.isOwner(msg.author);
 	}
 
 	async run(msg, args) {

--- a/src/commands/util/eval.js
+++ b/src/commands/util/eval.js
@@ -15,6 +15,7 @@ module.exports = class EvalCommand extends Command {
 			memberName: 'eval',
 			description: 'Executes JavaScript code.',
 			details: 'Only the bot owner(s) may use this command.',
+			ownerOnly: true,
 
 			args: [
 				{
@@ -26,10 +27,6 @@ module.exports = class EvalCommand extends Command {
 		});
 
 		this.lastResult = null;
-	}
-
-	hasPermission(msg) {
-		return this.client.isOwner(msg.author);
 	}
 
 	run(msg, args) {


### PR DESCRIPTION
Yes, I know I made this PR before. However, we didn't have `userPermissions` then, and this fits quite well with those options. Another difference is that the option is now checked in `hasPermission` in order to preserve the usability checking in the help command, just like `userPermissions`.