### PR TITLE
Make args.min and args.max give a useful response.

### DIFF
--- a/src/types/float.js
+++ b/src/types/float.js
@@ -7,7 +7,7 @@ class FloatArgumentType extends ArgumentType {
 
 	validate(value, msg, arg) {
 		const float = Number.parseFloat(value);
-		if(!Number.isNaN(float)) return false;
+		if(Number.isNaN(float)) return false;
 		if(arg.min !== null && typeof arg.min !== 'undefined' && float < arg.min) {
 			return `Please enter a number above or exactly ${arg.min}.`;
 		}

--- a/src/types/float.js
+++ b/src/types/float.js
@@ -8,11 +8,11 @@ class FloatArgumentType extends ArgumentType {
 	validate(value, msg, arg) {
 		const float = Number.parseFloat(value);
 		if(!Number.isNaN(float)) return false;
-		if(arg.min !== null && typeof arg.min !== 'undefined' && float <= arg.min) {
-			return `Please enter a number above ${arg.min}.`;
+		if(arg.min !== null && typeof arg.min !== 'undefined' && float < arg.min) {
+			return `Please enter a number above or exactly ${arg.min}.`;
 		}
-		if(arg.max !== null && typeof arg.max !== 'undefined' && float >= arg.max) {
-			return `Please enter a number below ${arg.max}.`;
+		if(arg.max !== null && typeof arg.max !== 'undefined' && float > arg.max) {
+			return `Please enter a number below or exactly ${arg.max}.`;
 		}
 		return true;
 	}

--- a/src/types/float.js
+++ b/src/types/float.js
@@ -7,9 +7,14 @@ class FloatArgumentType extends ArgumentType {
 
 	validate(value, msg, arg) {
 		const float = Number.parseFloat(value);
-		return !Number.isNaN(float) &&
-			(arg.min === null || typeof arg.min === 'undefined' || float >= arg.min) &&
-			(arg.max === null || typeof arg.max === 'undefined' || float <= arg.max);
+		if(!Number.isNaN(float)) return false;
+		if(arg.min !== null && typeof arg.min !== 'undefined' && float <= arg.min) {
+			return `Please enter a number above ${arg.min}.`;
+		}
+		if(arg.max !== null && typeof arg.max !== 'undefined' && float >= arg.max) {
+			return `Please enter a number below ${arg.max}.`;
+		}
+		return true;
 	}
 
 	parse(value) {

--- a/src/types/integer.js
+++ b/src/types/integer.js
@@ -8,11 +8,11 @@ class IntegerArgumentType extends ArgumentType {
 	validate(value, msg, arg) {
 		const int = Number.parseInt(value);
 		if(!Number.isNaN(int)) return false;
-		if(arg.min !== null && typeof arg.min !== 'undefined' && int <= arg.min) {
-			return `Please enter a number above ${arg.min}.`;
+		if(arg.min !== null && typeof arg.min !== 'undefined' && int < arg.min) {
+			return `Please enter a number above or exactly ${arg.min}.`;
 		}
-		if(arg.max !== null && typeof arg.max !== 'undefined' && int >= arg.max) {
-			return `Please enter a number below ${arg.max}.`;
+		if(arg.max !== null && typeof arg.max !== 'undefined' && int > arg.max) {
+			return `Please enter a number below or exactly ${arg.max}.`;
 		}
 		return true;
 	}

--- a/src/types/integer.js
+++ b/src/types/integer.js
@@ -7,7 +7,7 @@ class IntegerArgumentType extends ArgumentType {
 
 	validate(value, msg, arg) {
 		const int = Number.parseInt(value);
-		if(!Number.isNaN(int)) return false;
+		if(Number.isNaN(int)) return false;
 		if(arg.min !== null && typeof arg.min !== 'undefined' && int < arg.min) {
 			return `Please enter a number above or exactly ${arg.min}.`;
 		}

--- a/src/types/integer.js
+++ b/src/types/integer.js
@@ -7,9 +7,14 @@ class IntegerArgumentType extends ArgumentType {
 
 	validate(value, msg, arg) {
 		const int = Number.parseInt(value);
-		return !Number.isNaN(int) &&
-			(arg.min === null || typeof arg.min === 'undefined' || int >= arg.min) &&
-			(arg.max === null || typeof arg.max === 'undefined' || int <= arg.max);
+		if(!Number.isNaN(int)) return false;
+		if(arg.min !== null && typeof arg.min !== 'undefined' && int <= arg.min) {
+			return `Please enter a number above ${arg.min}.`;
+		}
+		if(arg.max !== null && typeof arg.max !== 'undefined' && int >= arg.max) {
+			return `Please enter a number below ${arg.max}.`;
+		}
+		return true;
 	}
 
 	parse(value) {

--- a/src/types/string.js
+++ b/src/types/string.js
@@ -6,9 +6,14 @@ class StringArgumentType extends ArgumentType {
 	}
 
 	validate(value, msg, arg) {
-		return Boolean(value) &&
-			(arg.min === null || typeof arg.min === 'undefined' || value.length >= arg.min) &&
-			(arg.max === null || typeof arg.max === 'undefined' || value.length <= arg.max);
+		if(!value) return false;
+		if(arg.min !== null && typeof arg.min !== 'undefined' && value.length <= arg.min) {
+			return `Please keep the ${arg.label} above ${arg.min} characters.`;
+		}
+		if(arg.max !== null && typeof arg.max !== 'undefined' && value.length >= arg.max) {
+			return `Please keep the ${arg.label} below ${arg.max} characters.`;
+		}
+		return true;
 	}
 
 	parse(value) {

--- a/src/types/string.js
+++ b/src/types/string.js
@@ -7,11 +7,11 @@ class StringArgumentType extends ArgumentType {
 
 	validate(value, msg, arg) {
 		if(!value) return false;
-		if(arg.min !== null && typeof arg.min !== 'undefined' && value.length <= arg.min) {
-			return `Please keep the ${arg.label} above ${arg.min} characters.`;
+		if(arg.min !== null && typeof arg.min !== 'undefined' && value.length < arg.min) {
+			return `Please keep the ${arg.label} above or exactly ${arg.min} characters.`;
 		}
-		if(arg.max !== null && typeof arg.max !== 'undefined' && value.length >= arg.max) {
-			return `Please keep the ${arg.label} below ${arg.max} characters.`;
+		if(arg.max !== null && typeof arg.max !== 'undefined' && value.length > arg.max) {
+			return `Please keep the ${arg.label} below or exactly ${arg.max} characters.`;
 		}
 		return true;
 	}


### PR DESCRIPTION
The user will be told that the text should be above/below a certain length/number if they enter something too low or too high instead of the slightly unhelpful in this context "Invalid <arg name>, please try again."