### PR TITLE
changed hard-coded reply to event emit

### DIFF
--- a/src/commands/message.js
+++ b/src/commands/message.js
@@ -132,7 +132,7 @@ class CommandMessage {
 			 * @event CommandoClient#commandBlocked
 			 * @param {CommandMessage} message - Command message that the command is running from
 			 * @param {string} reason - Reason that the command was blocked
-			 * (built-in reasons are `guildOnly`, `permission`, and `throttling`)
+			 * (built-in reasons are `guildOnly`, `disabled`, `permission`, and `throttling`)
 			 */
 			this.client.emit('commandBlocked', this, 'guildOnly');
 			return this.reply(`The \`${this.command.name}\` command must be used in a server channel.`);

--- a/src/dispatcher.js
+++ b/src/dispatcher.js
@@ -122,7 +122,7 @@ class CommandDispatcher {
 			if(!inhibited) {
 				if(cmdMsg.command) {
 					if(!cmdMsg.command.isEnabledIn(message.guild)) {
-						responses = await cmdMsg.reply(`The \`${cmdMsg.command.name}\` command is disabled.`);
+						this.client.emit('commandBlocked', cmdMsg, 'disabled');
 					} else if(!oldMessage || typeof oldCmdMsg !== 'undefined') {
 						responses = await cmdMsg.run();
 						if(typeof responses === 'undefined') responses = null; // eslint-disable-line max-depth


### PR DESCRIPTION
Previously you had no choice but to let the bot attempt to reply to a users message when it matched a command that was disabled on a given server.

This functionality could be rather annoying when you wanted a bot to remain quite and ignore requests for disabled commands. The only way to intercept this would be to build an inhibitor

With this change you can use the `client#commandBlocked` event to write custom logic to handle instances where the command is disabled.