### PR TITLE
Update docs to the proper version of node

### DIFF
--- a/docs/general/welcome.md
+++ b/docs/general/welcome.md
@@ -29,5 +29,5 @@ Additionally, it makes full use of ES2017's `async`/`await` functionality for cl
 - Command throttling/cooldowns
 
 ## Installation
-**Node 7.6.0 or newer is required.**  
-`npm install discord.js-commando --save`
+**Node 8.0.0 or newer is required.**
+`npm i discord.js-commando`

--- a/docs/general/welcome.md
+++ b/docs/general/welcome.md
@@ -29,5 +29,5 @@ Additionally, it makes full use of ES2017's `async`/`await` functionality for cl
 - Command throttling/cooldowns
 
 ## Installation
-**Node 8.0.0 or newer is required.**
+**Node 8.0.0 or newer is required.**  
 `npm i discord.js-commando`


### PR DESCRIPTION
The docs don't seem to update with the README, so this updates the docs welcome page to the proper node version.