### PR TITLE
Updated base.js to add the missing "commands" word

### DIFF
--- a/src/commands/base.js
+++ b/src/commands/base.js
@@ -243,7 +243,7 @@ class Command {
 					return `The \`${this.name}\` command requires you to have the "${permissions[missing[0]]}" permission.`;
 				}
 				return oneLine`
-					The \`${this.name}\` requires you to have the following permissions:
+					The \`${this.name}\` command requires you to have the following permissions:
 					${missing.map(perm => permissions[perm]).join(', ')}
 				`;
 			}


### PR DESCRIPTION
When there are more than one missing permissions, the prompt returns as "The [command name] requires you to have..." which made no sense to me, e.g. "The help requires you to have..."

Hence the added "commands" word.