### PR TITLE
Prevent help from erroring if there are tons of commands.

### DIFF
--- a/src/commands/util/help.js
+++ b/src/commands/util/help.js
@@ -59,6 +59,8 @@ module.exports = class HelpCommand extends Command {
 					messages.push(await msg.reply('Unable to send you the help DM. You probably have DMs disabled.'));
 				}
 				return messages;
+			} else if(commands.length > 15) {
+				return msg.reply('Multiple commands found. Please be more specific.');
 			} else if(commands.length > 1) {
 				return msg.reply(disambiguation(commands, 'commands'));
 			} else {


### PR DESCRIPTION
Sometimes, a bot might have more than enough commands to make the help command's disambiguation be longer than 2000 characters. Perhaps a bot has 225 commands and a user tries to do "`help a`". If enough commands have "a" in them, this might end badly.

This PR utilizes the same prevention method as the types to prevent this from happening. If more than 15 commands are found, it will simply send "Multiple commands found. Please be more specific." instead of erroring out.