### PR TITLE
Fix #103

### DIFF
--- a/src/errors/command-format.js
+++ b/src/errors/command-format.js
@@ -14,7 +14,7 @@ class CommandFormatError extends FriendlyError {
 				msg.command.format,
 				msg.guild ? undefined : null,
 				msg.guild ? undefined : null
-			)}. Use ${msg.usage(
+			)}. Use ${msg.anyUsage(
 				`help ${msg.command.name}`,
 				msg.guild ? undefined : null,
 				msg.guild ? undefined : null


### PR DESCRIPTION
The CommandFormatError message was using `msg.usage` instead of `msg.anyUsage`.

Fixes #103 