### PR TITLE
Drop require-all for fs.

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,8 +27,7 @@
 	"types": "./typings/index.d.ts",
 	"dependencies": {
 		"common-tags": "^1.0.0",
-		"escape-string-regexp": "^1.0.0",
-		"require-all": "^2.0.0"
+		"escape-string-regexp": "^1.0.0"
 	},
 	"devDependencies": {
 		"@types/node": "^8.0.0",

--- a/src/index.js
+++ b/src/index.js
@@ -116,7 +116,3 @@ module.exports = {
  * @external ShardingManager
  * @see {@link https://discord.js.org/#/docs/main/master/class/ShardingManager}
  */
-/**
- * @external RequireAllOptions
- * @see {@link https://www.npmjs.com/package/require-all}
- */

--- a/src/registry.js
+++ b/src/registry.js
@@ -231,7 +231,7 @@ class CommandRegistry {
 		const files = fs.readdirSync(filePath);
 		const types = [];
 		for(let type of files) {
-			if (filter && !filter.test(type)) continue;
+			if(filter && !filter.test(type)) continue;
 			type = require(path.join(filePath, type));
 			types.push(type);
 		}

--- a/src/registry.js
+++ b/src/registry.js
@@ -1,5 +1,6 @@
 const path = require('path');
 const discord = require('discord.js');
+const fs = require('fs');
 const Command = require('./commands/base');
 const CommandGroup = require('./commands/group');
 const CommandMessage = require('./commands/message');
@@ -157,19 +158,20 @@ class CommandRegistry {
 
 	/**
 	 * Registers all commands in a directory. The files must export a Command class constructor or instance.
-	 * @param {string|RequireAllOptions} options - The path to the directory, or a require-all options object
+	 * @param {string} filePath - The path to the directory
 	 * @return {CommandRegistry}
 	 */
-	registerCommandsIn(options) {
-		const obj = require('require-all')(options);
+	registerCommandsIn(filePath) {
+		const groups = fs.readdirSync(filePath);
 		const commands = [];
-		for(const group of Object.values(obj)) {
-			for(let command of Object.values(group)) {
-				if(typeof command.default === 'function') command = command.default;
+		for(const group of groups) {
+			const files = fs.readdirSync(path.join(filePath, group));
+			for(let command of files) {
+				command = require(path.join(filePath, group, command));
 				commands.push(command);
 			}
 		}
-		if(typeof options === 'string' && !this.commandsPath) this.commandsPath = options;
+		if(!this.commandsPath) this.commandsPath = filePath;
 		return this.registerCommands(commands);
 	}
 
@@ -219,13 +221,16 @@ class CommandRegistry {
 
 	/**
 	 * Registers all argument types in a directory. The files must export an ArgumentType class constructor or instance.
-	 * @param {string|RequireAllOptions} options - The path to the directory, or a require-all options object
+	 * @param {string} filePath - The path to the directory
 	 * @return {CommandRegistry}
 	 */
-	registerTypesIn(options) {
-		const obj = require('require-all')(options);
+	registerTypesIn(filePath) {
+		const files = fs.readdirSync(filePath);
 		const types = [];
-		for(const type of Object.values(obj)) types.push(type);
+		for(let type of files) {
+			type = require(path.join(filePath, type));
+			types.push(type);
+		}
 		return this.registerTypes(types);
 	}
 

--- a/src/registry.js
+++ b/src/registry.js
@@ -159,14 +159,16 @@ class CommandRegistry {
 	/**
 	 * Registers all commands in a directory. The files must export a Command class constructor or instance.
 	 * @param {string} filePath - The path to the directory
+	 * @param {RegExp} filter - A regular expression to filter files by
 	 * @return {CommandRegistry}
 	 */
-	registerCommandsIn(filePath) {
+	registerCommandsIn(filePath, filter) {
 		const groups = fs.readdirSync(filePath);
 		const commands = [];
 		for(const group of groups) {
 			const files = fs.readdirSync(path.join(filePath, group));
 			for(let command of files) {
+				if(filter && !filter.test(command)) continue;
 				command = require(path.join(filePath, group, command));
 				commands.push(command);
 			}
@@ -222,12 +224,14 @@ class CommandRegistry {
 	/**
 	 * Registers all argument types in a directory. The files must export an ArgumentType class constructor or instance.
 	 * @param {string} filePath - The path to the directory
+	 * @param {RegExp} filter - A regular expression to filter files by
 	 * @return {CommandRegistry}
 	 */
-	registerTypesIn(filePath) {
+	registerTypesIn(filePath, filter) {
 		const files = fs.readdirSync(filePath);
 		const types = [];
 		for(let type of files) {
+			if (filter && !filter.test(type)) continue;
 			type = require(path.join(filePath, type));
 			types.push(type);
 		}


### PR DESCRIPTION
This brings the dependency count down to two, by replacing `require-all` with basic `fs`. I tested it and it successfully loaded all commands and types.