### PR TITLE
Properly re-check empty status

### DIFF
--- a/src/commands/argument.js
+++ b/src/commands/argument.js
@@ -127,7 +127,7 @@ class Argument {
 	 * @return {Promise<ArgumentResult>}
 	 */
 	async obtain(msg, value, promptLimit = Infinity) {
-		const empty = this.isEmpty(value, msg);
+		let empty = this.isEmpty(value, msg);
 		if(empty && this.default !== null) {
 			return {
 				value: this.default,
@@ -192,6 +192,7 @@ class Argument {
 				};
 			}
 
+			empty = this.isEmpty(value, msg);
 			valid = await this.validate(value, msg);
 			/* eslint-enable no-await-in-loop */
 		}


### PR DESCRIPTION
The empty status of arguments is not re-checked at the end of the while loop, resulting in the prompt being permanently used if the initial command was empty.