### PR TITLE
Fix Commands:Load

### DIFF
--- a/src/commands/commands/load.js
+++ b/src/commands/commands/load.js
@@ -22,6 +22,7 @@ module.exports = class LoadCommandCommand extends Command {
 				{
 					key: 'command',
 					prompt: 'Which command would you like to load?',
+					type: 'string',
 					validate: val => new Promise(resolve => {
 						if(!val) return resolve(false);
 						const split = val.split(':');

--- a/src/commands/commands/load.js
+++ b/src/commands/commands/load.js
@@ -22,7 +22,7 @@ module.exports = class LoadCommandCommand extends Command {
 				{
 					key: 'command',
 					prompt: 'Which command would you like to load?',
-					type: 'string',
+					type: 'command',
 					validate: val => new Promise(resolve => {
 						if(!val) return resolve(false);
 						const split = val.split(':');


### PR DESCRIPTION
Without defining a type for the arg it would be seen as `null` in argument.js causing an error `Cannot read property 'isEmpty' of null` on line 351 of argument.js (see full error here: https://gist.github.com/Favna/174d4bd2543c6a40b38988d58ea723a2

Simply adding `'type': 'command'` below the `prompt` (just like in unload) property fixes this issue, thus making it possible to load commands on the fly again.

**Semantic versioning classification:**  
- [X] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.

---

p.s. eslint has been verified but from my experience Travis can be a real sob so I'm not getting my hopes up '_>'